### PR TITLE
[Enhance] CentOS、macOS support for "install.sh"

### DIFF
--- a/src/main/resources/shell/install.sh
+++ b/src/main/resources/shell/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-project="dst-server"    # 项目名称
+project="dst-admin"    # 项目名称
 sys=$(uname -s)         # 操作系统
 machine=$(uname -m)     # 架构版本
 
@@ -9,6 +9,7 @@ linux_steamcmd_link="https://steamcdn-a.akamaihd.net/client/installer/steamcmd_l
 
 # 创建Linux服务器环境
 create() {
+    echo "正在安装steamcmd..."
     res=`./steamcmd.sh +login anonymous +force_install_dir ~/dst +app_update 343050 validate +quit`
     res=$res | grep "0x202"
     if [ -z "$res" ]; then
@@ -17,7 +18,7 @@ create() {
         rm -rf ~/Steam
         rm -rf ~/dst
         rm -rf ~/steamcmd
-        exit -1;
+        exit 1;
     fi
     cp ~/steamcmd/linux32/libstdc++.so.6 ~/dst/bin/lib32/
     cd ~/dst/bin
@@ -28,7 +29,7 @@ create() {
     mkdir -p ~/.klei/DoNotStarveTogether/MyDediServer
     cd ~
     echo -e "${project} - 初始化完成\n${project} - 执行dstStart.sh脚本按照指示进行\n${project} - ./dstStart.sh"
-    exit 0
+    exit 1
 }
 
 # 配置环境
@@ -49,7 +50,7 @@ main() {
         mkdir -p ~/.klei/DoNotStarveTogether/MyDediServer
         cd ~
         echo -e "${project} - 初始化完成\n${project} - 执行dstStart.sh脚本按照指示进行\n${project} - ./dstStart.sh"
-        exit 0
+        exit 1
     fi
 
     # linux
@@ -61,8 +62,7 @@ main() {
             case $distribution in
                 CentOS)
                     echo "${project} - 安装CentOS依赖环境"
-                    mkdir ~/steamcmd
-                    cd ~/steamcmd
+                    mkdir ~/steamcmd && cd ~/steamcmd
                     wget ${linux_steamcmd_link}
                     tar -xvzf steamcmd_linux.tar.gz
                     sudo yum install -y glibc.i686 libstdc++.i686 ncurses-libs.i686 screen libcurl.i686
@@ -73,30 +73,13 @@ main() {
                 ;;
                 Ubuntu)
                     echo "${project} - 安装Ubuntu依赖环境"
-                    mkdir ~/steamcmd
-                    cd ~/steamcmd
+                    mkdir ~/steamcmd && cd ~/steamcmd
                     wget ${linux_steamcmd_link}
                     tar -xvzf steamcmd_linux.tar.gz
                     sudo apt-get update
                     sudo apt-get install -y lib32gcc1 libcurl4-gnutls-dev:i386 libsdl2-2.0 libsdl2-dev screen
                     sudo apt-get install -y libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl-gfx1.2-dev
                     create
-                ;;
-                ManjaroLinux)
-                    echo "${project} - 安装Manjaro依赖环境，请根据提示安装"
-                    sudo pacman -Sy base-devel
-                    git clone https://aur.archlinux.org/steamcmd.git
-                    cd steamcmd
-                    makepkg -si
-                    ./steamcmd +login anonymous +force_install_dir ~/dst +app_update 343050 validate +quit
-                    cp ~/steamcmd/linux32/libstdc++.so.6 ~/dst/bin/lib32/
-                    cd ~/dst/bin
-                    echo ./dontstarve_dedicated_server_nullrenderer -console -cluster MyDediServer -shard Master > overworld.sh
-                    echo ./dontstarve_dedicated_server_nullrenderer -console -cluster MyDediServer -shard Caves > cave.sh
-                    chmod +x overworld.sh
-                    chmod +x cave.sh
-                    mkdir -p ~/.klei/DoNotStarveTogether/MyDediServer
-                    cd ~
                 ;;
                 *)
                     echo "${project} - 暂不支持该Linux发行版 ${distribution}"

--- a/src/main/resources/shell/install.sh
+++ b/src/main/resources/shell/install.sh
@@ -1,29 +1,92 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
-sudo apt-get update
-sudo apt-get install -y lib32gcc1
-sudo apt-get install -y libcurl4-gnutls-dev:i386
-sudo apt-get install -y screen
+project="dst-server"    # 项目名称
+sys=$(uname -s)         # 操作系统
+machine=$(uname -m)     # 架构版本
 
-mkdir ~/steamcmd
-cd ~/steamcmd
+darwin_steamcmd_link="https://steamcdn-a.akamaihd.net/client/installer/steamcmd_osx.tar.gz"
+linux_steamcmd_link="https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz"
 
-wget https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz
-tar -xvzf steamcmd_linux.tar.gz
-./steamcmd.sh +login anonymous +force_install_dir ~/dst +app_update 343050 validate +quit
+# 创建服务器环境
+create() {
+    ./steamcmd.sh +login anonymous +force_install_dir ~/dst +app_update 343050 validate +quit
+    cp ~/steamcmd/linux32/libstdc++.so.6 ~/dst/bin/lib32/
+    cd ~/dst/bin
+    echo ./dontstarve_dedicated_server_nullrenderer -console -cluster MyDediServer -shard Master > overworld.sh
+    echo ./dontstarve_dedicated_server_nullrenderer -console -cluster MyDediServer -shard Caves > cave.sh
+    chmod +x overworld.sh
+    chmod +x cave.sh
+    mkdir -p ~/.klei/DoNotStarveTogether/MyDediServer
+    cd ~
+    echo -e "${project} - 初始化完成\n${project} - 执行dstStart.sh脚本按照指示进行\n${project} - ./dstStart.sh"
+    exit 0
+}
 
-cp ~/steamcmd/linux32/libstdc++.so.6 ~/dst/bin/lib32/
+# 配置环境
+main() {
+    # mac
+    if (( "$sys" == "Darwin" )); then
+        echo "${project} - 操作系统：MacOS"
+        mkdir ~/steamcmd
+        cd ~/steamcmd
+        curl -sqL ${darwin_steamcmd_link} | tar zxvf -
+        create
+    fi
 
-cd ~/dst/bin
-echo ./dontstarve_dedicated_server_nullrenderer -console -cluster MyDediServer -shard Master > overworld.sh
-echo ./dontstarve_dedicated_server_nullrenderer -console -cluster MyDediServer -shard Caves > cave.sh
+    # linux
+    if (( "$sys" == "Linux" )); then
+        distribution=$(lsb_release -i | awk '{print $3}')   # 发行版本
+        echo "${project} - 操作系统：Linux"
+        echo "${project} - ${distribution} ${machine}"
+        if (( "$machine" == "x86_64" )); then
+            case $distribution in
+                CentOS)
+                    echo "${project} - 安装CentOS依赖环境"
+                    mkdir ~/steamcmd
+                    cd ~/steamcmd
+                    wget ${linux_steamcmd_link}
+                    tar -xvzf steamcmd_linux.tar.gz
+                    sudo yum install -y glibc.i686 libstdc++.i686
+                    sudo yum install -y screen
+                    create
+                ;;
+                Ubuntu)
+                    echo "${project} - 安装Ubuntu依赖环境"
+                    mkdir ~/steamcmd
+                    cd ~/steamcmd
+                    wget ${linux_steamcmd_link}
+                    tar -xvzf steamcmd_linux.tar.gz
+                    sudo apt-get update
+                    sudo apt-get install -y lib32gcc1
+                    sudo apt-get install -y libcurl4-gnutls-dev:i386
+                    sudo apt-get install -y screen
+                    create
+                ;;
+                ManjaroLinux)
+                    echo "${project} - 安装Manjaro依赖环境，请根据提示安装"
+                    pacman -Sy base-devel
+                    git clone https://aur.archlinux.org/steamcmd.git
+                    cd steamcmd
+                    makepkg -darwin_steamcmd_link
+                    # ./steamcmd
+                    ./steamcmd +login anonymous +force_install_dir ~/dst +app_update 343050 validate +quit
+                    cp ~/steamcmd/linux32/libstdc++.so.6 ~/dst/bin/lib32/
+                    cd ~/dst/bin
+                    echo ./dontstarve_dedicated_server_nullrenderer -console -cluster MyDediServer -shard Master > overworld.sh
+                    echo ./dontstarve_dedicated_server_nullrenderer -console -cluster MyDediServer -shard Caves > cave.sh
+                    chmod +x overworld.sh
+                    chmod +x cave.sh
+                    mkdir -p ~/.klei/DoNotStarveTogether/MyDediServer
+                    cd ~
+                ;;
+                *)
+                    echo "${project} - 暂不支持该Linux发行版 ${distribution}"
+                ;;
+            esac
+        else
+            echo "${project} - 不受支持的架构版本 ${machine}"
+        fi
+    fi
+}
 
-chmod +x overworld.sh
-chmod +x cave.sh
-
-mkdir -p ~/.klei/DoNotStarveTogether/MyDediServer
-
-cd ~
-
-
-
+main

--- a/src/main/resources/shell/install.sh
+++ b/src/main/resources/shell/install.sh
@@ -9,7 +9,16 @@ linux_steamcmd_link="https://steamcdn-a.akamaihd.net/client/installer/steamcmd_l
 
 # 创建Linux服务器环境
 create() {
-    ./steamcmd.sh +login anonymous +force_install_dir ~/dst +app_update 343050 validate +quit
+    res=`./steamcmd.sh +login anonymous +force_install_dir ~/dst +app_update 343050 validate +quit`
+    res=$res | grep "0x202"
+    if [ -z "$res" ]; then
+        echo "${project} - 0x202错误 请检查可用空间是否 > 24GB"
+        echo "${project} - 删除可能的 ~/steamcmd ~/Steam ~/dst 目录后重试 ./install.sh"
+        rm -rf ~/Steam
+        rm -rf ~/dst
+        rm -rf ~/steamcmd
+        exit -1;
+    fi
     cp ~/steamcmd/linux32/libstdc++.so.6 ~/dst/bin/lib32/
     cd ~/dst/bin
     echo ./dontstarve_dedicated_server_nullrenderer -console -cluster MyDediServer -shard Master > overworld.sh
@@ -69,17 +78,16 @@ main() {
                     wget ${linux_steamcmd_link}
                     tar -xvzf steamcmd_linux.tar.gz
                     sudo apt-get update
-                    sudo apt-get install -y lib32gcc1
-                    sudo apt-get install -y libcurl4-gnutls-dev:i386
-                    sudo apt-get install -y screen
+                    sudo apt-get install -y lib32gcc1 libcurl4-gnutls-dev:i386 libsdl2-2.0 libsdl2-dev screen
+                    sudo apt-get install -y libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl-gfx1.2-dev
                     create
                 ;;
                 ManjaroLinux)
                     echo "${project} - 安装Manjaro依赖环境，请根据提示安装"
-                    pacman -Sy base-devel
+                    sudo pacman -Sy base-devel
                     git clone https://aur.archlinux.org/steamcmd.git
                     cd steamcmd
-                    makepkg -darwin_steamcmd_link
+                    makepkg -si
                     ./steamcmd +login anonymous +force_install_dir ~/dst +app_update 343050 validate +quit
                     cp ~/steamcmd/linux32/libstdc++.so.6 ~/dst/bin/lib32/
                     cd ~/dst/bin

--- a/src/main/resources/shell/install.sh
+++ b/src/main/resources/shell/install.sh
@@ -25,12 +25,13 @@ create() {
 # 配置环境
 main() {
     # mac
-    if (( "$sys" == "Darwin" )); then
+    if [ "$sys" == "Darwin" ]; then
         echo "${project} - 操作系统：MacOS"
         mkdir ~/steamcmd && cd ~/steamcmd
         wget ${darwin_steamcmd_link}
         tar -zxvf steamcmd_osx.tar.gz
         ./steamcmd.sh +login anonymous +force_install_dir ~/dst +app_update 343050 validate +quit
+        cd ~/dst
         mkdir ~/dst/bin
         echo ~/dst/dontstarve_dedicated_server_nullrenderer.app/Contents/MacOS/dontstarve_dedicated_server_nullrenderer -console -cluster MyDediServer -shard Master > ~/dst/bin/overworld.sh
         echo ~/dst/dontstarve_dedicated_server_nullrenderer.app/Contents/MacOS/dontstarve_dedicated_server_nullrenderer -console -cluster MyDediServer -shard Caves > ~/dst/bin/cave.sh
@@ -43,11 +44,11 @@ main() {
     fi
 
     # linux
-    if (( "$sys" == "Linux" )); then
+    if [ "$sys" == "Linux" ]; then
         distribution=$(lsb_release -i | awk '{print $3}')   # 发行版本
         echo "${project} - 操作系统：Linux"
         echo "${project} - ${distribution} ${machine}"
-        if (( "$machine" == "x86_64" )); then
+        if [ "$machine" == "x86_64" ]; then
             case $distribution in
                 CentOS)
                     echo "${project} - 安装CentOS依赖环境"
@@ -55,8 +56,10 @@ main() {
                     cd ~/steamcmd
                     wget ${linux_steamcmd_link}
                     tar -xvzf steamcmd_linux.tar.gz
-                    sudo yum install -y glibc.i686 libstdc++.i686
-                    sudo yum install -y screen
+                    sudo yum install -y glibc.i686 libstdc++.i686 ncurses-libs.i686 screen libcurl.i686
+                    sudo yum install -y SDL2.x86_64 SDL2_gfx-devel.x86_64 SDL2_image-devel.x86_64 SDL2_ttf-devel.x86_64
+                    # CentOS需要建立libcurl-gnutls.so.4软连接
+                    ln -s /usr/lib/libcurl.so.4 /usr/lib/libcurl-gnutls.so.4
                     create
                 ;;
                 Ubuntu)

--- a/src/main/resources/shell/install.sh
+++ b/src/main/resources/shell/install.sh
@@ -7,7 +7,7 @@ machine=$(uname -m)     # 架构版本
 darwin_steamcmd_link="https://steamcdn-a.akamaihd.net/client/installer/steamcmd_osx.tar.gz"
 linux_steamcmd_link="https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz"
 
-# 创建服务器环境
+# 创建Linux服务器环境
 create() {
     ./steamcmd.sh +login anonymous +force_install_dir ~/dst +app_update 343050 validate +quit
     cp ~/steamcmd/linux32/libstdc++.so.6 ~/dst/bin/lib32/
@@ -27,10 +27,19 @@ main() {
     # mac
     if (( "$sys" == "Darwin" )); then
         echo "${project} - 操作系统：MacOS"
-        mkdir ~/steamcmd
-        cd ~/steamcmd
-        curl -sqL ${darwin_steamcmd_link} | tar zxvf -
-        create
+        mkdir ~/steamcmd && cd ~/steamcmd
+        wget ${darwin_steamcmd_link}
+        tar -zxvf steamcmd_osx.tar.gz
+        ./steamcmd.sh +login anonymous +force_install_dir ~/dst +app_update 343050 validate +quit
+        mkdir ~/dst/bin
+        echo ~/dst/dontstarve_dedicated_server_nullrenderer.app/Contents/MacOS/dontstarve_dedicated_server_nullrenderer -console -cluster MyDediServer -shard Master > ~/dst/bin/overworld.sh
+        echo ~/dst/dontstarve_dedicated_server_nullrenderer.app/Contents/MacOS/dontstarve_dedicated_server_nullrenderer -console -cluster MyDediServer -shard Caves > ~/dst/bin/cave.sh
+        chmod +x ~/dst/bin/overworld.sh
+        chmod +x ~/dst/bin/cave.sh
+        mkdir -p ~/.klei/DoNotStarveTogether/MyDediServer
+        cd ~
+        echo -e "${project} - 初始化完成\n${project} - 执行dstStart.sh脚本按照指示进行\n${project} - ./dstStart.sh"
+        exit 0
     fi
 
     # linux
@@ -68,7 +77,6 @@ main() {
                     git clone https://aur.archlinux.org/steamcmd.git
                     cd steamcmd
                     makepkg -darwin_steamcmd_link
-                    # ./steamcmd
                     ./steamcmd +login anonymous +force_install_dir ~/dst +app_update 343050 validate +quit
                     cp ~/steamcmd/linux32/libstdc++.so.6 ~/dst/bin/lib32/
                     cd ~/dst/bin


### PR DESCRIPTION
install.sh支持CentOS、macOS环境的安装。
已经在以下环境测试运行：
```
macOS
Darwin yankai.local 19.6.0 Darwin Kernel Version 19.6.0: Mon Aug 31 22:12:52 PDT 2020; root:xnu-6153.141.2~1/RELEASE_X86_64 x86_64

CentOS
LSB Version:	:core-4.1-amd64:core-4.1-noarch
Distributor ID:	CentOS
Description:	CentOS Linux release 7.7.1908 (Core)
Release:	7.7.1908
Codename:	Core
```