### PR TITLE
系统设置-实验室-智能更新，修改为从steam服务器获取数据，不再为空

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
         <!--shiro权限管理框架版本：component.shiro-->
-        <shiro.version>1.7.1</shiro.version>
+        <shiro.version>1.9.0</shiro.version>
     </properties>
 
     <dependencies>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10.8</version>
+            <version>2.13.3</version>
         </dependency>
 
         <dependency>
@@ -64,13 +64,13 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.4</version>
+            <version>3.12.0</version>
         </dependency>
 
         <dependency>
             <groupId>cn.hutool</groupId>
             <artifactId>hutool-all</artifactId>
-            <version>5.3.2</version>
+            <version>5.8.3</version>
         </dependency>
 
         <dependency>
@@ -82,19 +82,13 @@
         <dependency>
             <groupId>com.github.oshi</groupId>
             <artifactId>oshi-core</artifactId>
-            <version>5.3.6</version>
+            <version>6.1.6</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>29.0-jre</version>
+            <version>31.1-jre</version>
         </dependency>
-
-<!--        <dependency>-->
-<!--            <groupId>org.codehaus.groovy</groupId>-->
-<!--            <artifactId>groovy</artifactId>-->
-<!--            <version>2.4.5</version>-->
-<!--        </dependency>-->
 
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
         <!--shiro权限管理框架版本：component.shiro-->
-        <shiro.version>1.9.0</shiro.version>
+        <shiro.version>1.7.1</shiro.version>
     </properties>
 
     <dependencies>
@@ -64,13 +64,13 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
+            <version>3.4</version>
         </dependency>
 
         <dependency>
             <groupId>cn.hutool</groupId>
             <artifactId>hutool-all</artifactId>
-            <version>5.8.3</version>
+            <version>5.3.2</version>
         </dependency>
 
         <dependency>
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>com.github.oshi</groupId>
             <artifactId>oshi-core</artifactId>
-            <version>6.1.6</version>
+            <version>5.3.6</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>cn.hutool</groupId>
             <artifactId>hutool-all</artifactId>
-            <version>5.3.2</version>
+            <version>5.8.3</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.3</version>
+            <version>2.9.10.8</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/tugos/dst/admin/service/CoreScheduleService.java
+++ b/src/main/java/com/tugos/dst/admin/service/CoreScheduleService.java
@@ -4,6 +4,7 @@ package com.tugos.dst.admin.service;
 import cn.hutool.core.date.DatePattern;
 import cn.hutool.core.date.DateTime;
 import cn.hutool.core.date.DateUtil;
+import cn.hutool.core.date.LocalDateTimeUtil;
 import com.google.common.collect.Range;
 import com.tugos.dst.admin.enums.StartTypeEnum;
 import com.tugos.dst.admin.utils.*;
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
 import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -85,18 +87,18 @@ public class CoreScheduleService {
     @Scheduled(fixedDelay = 1000 * 60 * 30, initialDelay = 1000 * 60 * 30)
     public void smartUpdateGame() {
         Boolean smartUpdate = DstConfigData.smartUpdate;
+        //获取一次游戏版本
+        DstVersionUtils.getSteamVersionWithTitle();
         if (smartUpdate != null && smartUpdate) {
-            String steamVersion = DstVersionUtils.getSteamVersion();
-            String localVersion = DstVersionUtils.getLocalVersion();
-            if (StringUtils.isNoneBlank(steamVersion, localVersion)) {
-                long sv = Long.parseLong(steamVersion);
-                long lv = Long.parseLong(localVersion);
-                if (sv > lv) {
+            LocalDateTime gameVersionTime = DstVersionUtils.gameVersionTime;
+            LocalDateTime lastUpdateTime = DstVersionUtils.lastUpdateTime;
+            if (gameVersionTime != null && lastUpdateTime != null) {
+                if (lastUpdateTime.isAfter(gameVersionTime)) {
                     log.info("智能更新进行...");
                     onlyUpdateGame();
                 }
             } else {
-                log.info("拿不到最新的版本号：steamVersion={},localVersion={}", steamVersion, localVersion);
+                log.info("拿不到最新的版本号：steamVersion={},localVersion={}", gameVersionTime, lastUpdateTime);
             }
         }
     }
@@ -165,6 +167,7 @@ public class CoreScheduleService {
         if (notStartMaster && notStartCaves) {
             //都不启动
         }
+        DstVersionUtils.lastUpdateTime = LocalDateTimeUtil.of(new Date());
     }
 
 

--- a/src/main/java/com/tugos/dst/admin/service/ShellService.java
+++ b/src/main/java/com/tugos/dst/admin/service/ShellService.java
@@ -1,11 +1,9 @@
 package com.tugos.dst.admin.service;
 
+import cn.hutool.core.date.LocalDateTimeUtil;
 import com.tugos.dst.admin.common.ResultVO;
 import com.tugos.dst.admin.enums.DstLogTypeEnum;
-import com.tugos.dst.admin.utils.DstConstant;
-import com.tugos.dst.admin.utils.FileUtils;
-import com.tugos.dst.admin.utils.ModFileUtil;
-import com.tugos.dst.admin.utils.ShellUtil;
+import com.tugos.dst.admin.utils.*;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -14,6 +12,7 @@ import org.springframework.stereotype.Service;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -223,6 +222,8 @@ public class ShellService {
         //优雅关闭
         this.elegantShutdownMaster();
         this.elegantShutdownCaves();
+        //保存更新时间
+        DstVersionUtils.lastUpdateTime = LocalDateTimeUtil.of(new Date());
         return ShellUtil.runShell(DstConstant.UPDATE_GAME_CMD);
     }
 

--- a/src/main/java/com/tugos/dst/admin/service/SystemService.java
+++ b/src/main/java/com/tugos/dst/admin/service/SystemService.java
@@ -135,7 +135,7 @@ public class SystemService {
      * @return 版本号
      */
     public Map<String,String> getVersion() {
-        String steamVersion = DstVersionUtils.getSteamVersion();
+        String steamVersion = DstVersionUtils.getSteamVersionWithTitle();
         String localVersion = DstVersionUtils.getLocalVersion();
         Map<String,String> map = new HashMap<>(16);
         map.put("steamVersion",steamVersion);

--- a/src/main/java/com/tugos/dst/admin/utils/DstVersionUtils.java
+++ b/src/main/java/com/tugos/dst/admin/utils/DstVersionUtils.java
@@ -19,6 +19,7 @@ import java.io.FileInputStream;
 import java.io.InputStreamReader;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 
@@ -107,6 +108,9 @@ public class DstVersionUtils {
             }
         } catch (Exception e) {
             log.error("获取本地游戏版本号失败：", e);
+        }
+        if (lastUpdateTime == null){
+            lastUpdateTime = LocalDateTimeUtil.of(new Date());
         }
         return lastUpdateTime + "    " + "版本:" + version;
     }

--- a/src/main/java/com/tugos/dst/admin/utils/DstVersionUtils.java
+++ b/src/main/java/com/tugos/dst/admin/utils/DstVersionUtils.java
@@ -85,7 +85,7 @@ public class DstVersionUtils {
                 gameVersionTime = localDateTime;
             }
             String postTime = LocalDateTimeUtil.format(localDateTime, DatePattern.NORM_DATETIME_PATTERN);
-            versionWithTitle = postTime + "&nbsp&nbsp&nbsp&nbsp" + eventName;
+            versionWithTitle = postTime + "||" + eventName;
         } catch (Exception e) {
             log.error("从steam获取最新的饥荒版本号失败：{}", e.getMessage());
         }
@@ -112,7 +112,7 @@ public class DstVersionUtils {
         if (lastUpdateTime == null){
             lastUpdateTime = LocalDateTimeUtil.of(new Date());
         }
-        return LocalDateTimeUtil.format(lastUpdateTime, DatePattern.NORM_DATETIME_PATTERN) + "&nbsp&nbsp&nbsp&nbsp" + "版本:" + version;
+        return LocalDateTimeUtil.format(lastUpdateTime, DatePattern.NORM_DATETIME_PATTERN) + "||" + "版本:" + version;
     }
 
 

--- a/src/main/java/com/tugos/dst/admin/utils/DstVersionUtils.java
+++ b/src/main/java/com/tugos/dst/admin/utils/DstVersionUtils.java
@@ -85,7 +85,7 @@ public class DstVersionUtils {
                 gameVersionTime = localDateTime;
             }
             String postTime = LocalDateTimeUtil.format(localDateTime, DatePattern.NORM_DATETIME_PATTERN);
-            versionWithTitle = postTime + "    " + eventName;
+            versionWithTitle = postTime + "&nbsp&nbsp&nbsp&nbsp" + eventName;
         } catch (Exception e) {
             log.error("从steam获取最新的饥荒版本号失败：{}", e.getMessage());
         }
@@ -112,7 +112,7 @@ public class DstVersionUtils {
         if (lastUpdateTime == null){
             lastUpdateTime = LocalDateTimeUtil.of(new Date());
         }
-        return lastUpdateTime + "    " + "版本:" + version;
+        return LocalDateTimeUtil.format(lastUpdateTime, DatePattern.NORM_DATETIME_PATTERN) + "&nbsp&nbsp&nbsp&nbsp" + "版本:" + version;
     }
 
 

--- a/src/main/java/com/tugos/dst/admin/utils/DstVersionUtils.java
+++ b/src/main/java/com/tugos/dst/admin/utils/DstVersionUtils.java
@@ -5,6 +5,7 @@ import cn.hutool.core.date.LocalDateTimeUtil;
 import cn.hutool.http.HttpRequest;
 import cn.hutool.http.HttpUtil;
 import cn.hutool.json.JSON;
+import cn.hutool.json.JSONArray;
 import cn.hutool.json.JSONObject;
 import cn.hutool.json.JSONUtil;
 import lombok.extern.slf4j.Slf4j;
@@ -71,13 +72,14 @@ public class DstVersionUtils {
         try {
             String info = HttpUtil.get("https://store.steampowered.com/events/ajaxgetadjacentpartnerevents/?appid=322330&count_before=0&count_after=3&lang_list=6_0");
             JSONObject gameNewsInfo = JSONUtil.parseObj(info);
-            JSONObject events = gameNewsInfo.getJSONObject("events");
+            JSONArray events = gameNewsInfo.getJSONArray("events");
+            JSONObject event = events.getJSONObject(0);
             //活动名称
-            String eventName = events.getStr("event_name");
+            String eventName = event.getStr("event_name");
             //活动类型
-            Integer eventType = events.getInt("event_type");
+            Integer eventType = event.getInt("event_type");
             //获取发布时间
-            LocalDateTime localDateTime = LocalDateTimeUtil.ofUTC(events.getJSONObject("announcement_body").getInt("posttime"));
+            LocalDateTime localDateTime = LocalDateTimeUtil.ofUTC(event.getJSONObject("announcement_body").getLong("posttime") * 1000);
             if (eventType == 14 || eventType == 12) {
                 gameVersionTime = localDateTime;
             }

--- a/src/main/java/com/tugos/dst/admin/utils/DstVersionUtils.java
+++ b/src/main/java/com/tugos/dst/admin/utils/DstVersionUtils.java
@@ -80,7 +80,7 @@ public class DstVersionUtils {
             //活动类型
             Integer eventType = event.getInt("event_type");
             //获取发布时间
-            LocalDateTime localDateTime = LocalDateTimeUtil.ofUTC(event.getJSONObject("announcement_body").getLong("posttime") * 1000);
+            LocalDateTime localDateTime = LocalDateTimeUtil.of(event.getJSONObject("announcement_body").getLong("posttime") * 1000);
             if (eventType == 14 || eventType == 12) {
                 gameVersionTime = localDateTime;
             }


### PR DESCRIPTION
从原来的api改为从steam服务器获取数据
可以展示更新内容及时间，更加准确
修改原智能更新方法为最新的方法
更新后效果如下图所示：
![image](https://user-images.githubusercontent.com/43815714/177037010-2ffbdfa8-3a07-45cc-b6c5-20dee876c6fe.png)
