### PR TITLE
fix:Docker镜像大小、日志输出、启动问题改进

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -21,7 +21,7 @@
 2.  默认用户名/密码 admin/123456
 3.  饥荒监听端口**10888，10998，10999**（建议开放所有端口，避免一些问题）
 
-## docker版本部署请参考：[点击查看](https://github.com/qinming99/dst-admin/blob/master/file/README.md)
+## docker版本部署请参考：[点击查看](https://github.com/qinming99/dst-admin/blob/master/docker/README-zh.md)
 
 ## 如果需要租赁成品服务器： [点击查看](http://download.tugos.cn/img/taobao_ad.jpg)
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ java -jar dst-admin.jar
 ./dstStart.sh
 ```
 
+## Docker Support：[link](https://github.com/qinming99/dst-admin/blob/master/docker/README.md)
+
 ## Preview 
 
 ![img](https://github.com/qinming99/dst-admin/blob/master/images/image1.png)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,16 +1,21 @@
-FROM ubuntu:16.04
+FROM debian:stretch-slim
 
-RUN sed -i "s@http://.*archive.ubuntu.com@http://repo.huaweicloud.com@g" /etc/apt/sources.list \
-    && sed -i "s@http://.*security.ubuntu.com@http://repo.huaweicloud.com@g" /etc/apt/sources.list
+ENV LANG C.UTF-8
+RUN rm -f /etc/localtime \
+    && ln -sv /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
+    && echo "Asia/Shanghai" > /etc/timezone
+
+RUN echo "" > /etc/apt/sources.list
+RUN echo "deb http://mirrors.tuna.tsinghua.edu.cn/debian/ stretch main contrib non-free" >> /etc/apt/sources.list
+RUN echo "deb http://mirrors.tuna.tsinghua.edu.cn/debian/ stretch-updates main contrib non-free" >> /etc/apt/sources.list
+RUN echo "deb http://mirrors.tuna.tsinghua.edu.cn/debian/ stretch-backports main contrib non-free" >> /etc/apt/sources.list
+RUN echo "deb http://mirrors.tuna.tsinghua.edu.cn/debian-security stretch/updates main contrib non-free" >> /etc/apt/sources.list
 
 VOLUME /root
 
 ADD dst-admin.jar dst-admin.jar
 ADD dst_admin_docker.sh dst_admin_docker.sh
 RUN chmod 755 dst_admin_docker.sh
-
-ENV LANG C.UTF-8
-ENV TZ=Asia/Shanghai
 
 RUN dpkg --add-architecture i386 \
     && apt-get update \
@@ -23,7 +28,9 @@ RUN dpkg --add-architecture i386 \
         wget \
         ca-certificates \
         openjdk-8-jre \
-        screen
+        screen \
+        sudo \
+    && apt-get clean
 
 EXPOSE 8080/tcp
 EXPOSE 10888/udp

--- a/docker/README-zh.md
+++ b/docker/README-zh.md
@@ -1,0 +1,52 @@
+# Docker 构建指南
+
+- author: [@dzzhyk](https://github.com/dzzhyk)
+- update: 2023-01-27 11:44:11
+
+**首先请确保服务器已经安装docker环境，且服务器架构amd64 (操作系统: Win|MacOS|Linux均可)**
+
+[镜像帮助及常见问题](https://hub.docker.com/r/dzzhyk/dst-admin)
+
+## 1. 使用已有镜像
+
+1. 容器首次启动时自动安装`steamcmd`、`饥荒服务端`并启动`dst-admin`
+2. 需要服务器开放8080、10888、10998-10999端口；开服完成后，访问8080端口进入后台管理界面
+3. 容器入口脚本为`dst_admin_docker.sh`，可以进入容器后自行修改
+
+    ```shell
+    $ docker pull dzzhyk/dst-admin:latest
+    $ docker run --name dst-admin -d -p8080:8080 -p10888:10888/udp -p10998-10999:10998-10999/udp dzzhyk/dst-admin:latest
+    ```
+
+4. 容器启动日志、dst-admin日志
+
+    ```shell
+    $ docker logs dst-admin
+    ```
+
+5. 如果你使用了某些Docker镜像源，那么可能latest拉取到的非最新版本，推荐你用docker官方国内源 https://registry.docker-cn.com
+
+6. 容器启动时会自动检查steamcmd和饥荒服务端更新，手动触发方式：
+
+    ```shell
+    $ docker restart dst-admin
+    ```
+
+## 2. 手动构建镜像
+
+1. 打开终端terminal，cd进入docker目录，执行build_image.sh脚本
+
+   ```shell
+   $ cd docker
+   $ ./build_image.sh <Docker用户名> <dst-admin版本>
+   # 例如: ./build_image.sh wolfgang 1.5.0
+   ```
+
+2. 构建完成后，查看并启动构建好的image:
+
+   ```shell
+   $ docker images
+   $ docker run --name dst-admin -d -p8080:8080 -p10888:10888/udp -p10998-10999:10998-10999/udp wolfgang/dst-admin:v1.5.0
+   ```
+
+   构建镜像速度依据构建机网络决定，默认docker源国内并不稳定，如遇网络错误、构建慢请尝试镜像源、科学上网。

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,50 +1,50 @@
-# Docker 构建指南
+# Docker Support
 
 - author: [@dzzhyk](https://github.com/dzzhyk)
-- update: 2022-12-05 20:16:42
+- update: 2023-01-27 11:44:11
 
-**首先请确保服务器已经安装docker环境，且服务器架构amd64 (操作系统: Win|MacOS|Linux均可)**
+**Make sure install Docker env FIRST with arch type: amd64 (Win|MacOS|Linux)**
 
-## 1. 使用已有镜像
+[browse in dockerhub.com](https://hub.docker.com/r/dzzhyk/dst-admin)
 
-1. 容器首次启动时自动安装steamcmd、饥荒服务端并启动dst-admin
-2. 需要服务器开放8080、10888、10998-10999端口；开服完成后，访问8080端口进入后台管理界面
-3. 容器入口脚本为`dst_admin_docker.sh`，可以进入容器后自行修改
+## 1. Quick Start
 
-```shell script
-$ docker pull dzzhyk/dst-admin:latest
-$ docker run --name dst-admin -d -p8080:8080 -p10888:10888 -p10998-10999:10998-10999 dzzhyk/dst-admin:latest
-```
+1. Automatically install `steamcmd`, `Don't Starve server` and start `dst-admin` when the container starts for the first
+   time
+2. Ports 8080, 10888, and 1098-10999 must be enabled on the server. After the server is started, access port 8080 to go
+   to the background management page
+3. The container ENTRYPOINT is `dst_admin_docker.sh`. You can modify it after entering the container
 
-4. 容器启动日志、dst-admin日志
+   ```shell
+   $ docker pull dzzhyk/dst-admin:latest
+   $ docker run --name dst-admin -d -p8080:8080 -p10888:10888/udp -p10998-10999:10998-10999/udp dzzhyk/dst-admin:latest
+   ```
 
-```shell script
-$ docker logs dst-admin
-```
+4. Check `dst-admin` log
 
-5. 注意：如果你使用了某些Docker镜像源，那么可能latest拉取到的非最新版本，此时请手动尝试拉取新版：
+   ```shell
+   $ docker logs dst-admin
+   ```
 
-```shell script
-$ docker pull dzzhyk/dst-admin:v最新版本号
-```
+5. Restart container to check for updates for `steamcmd` and `Don't Starve server`
 
-## 2. 手动构建镜像
+   ```shell
+   $ docker restart dst-admin
+   ```
 
-这里以1.5.0为例
+## 2. Build images
 
-1. 打开终端terminal，cd进入docker目录，执行build_image.sh脚本
+1. Open terminal and change dictionary into `dst-admin/docker`，exec build_image.sh
 
-```shell script
-$ cd docker
-$ ./build_image.sh <Docker用户名> <dst-admin版本>
-# 例如: ./build_image.sh wolfgang 1.5.0
-```
+   ```shell
+   $ cd docker
+   $ ./build_image.sh <Docker username> <dst-admin version>
+   # For example: ./build_image.sh wolfgang 1.5.0
+   ```
 
-2. 构建完成后，查看并启动构建好的image:
+2. Check your own image:
 
-```shell script
-$ docker images
-$ docker run --name dst-admin -d -p8080:8080 -p10888:10888 -p10998-10999:10998-10999 wolfgang/dst-admin:v1.5.0
-```
-
-构建镜像速度依据构建机网络决定，默认docker源国内并不稳定，如遇网络错误、构建慢请尝试镜像源、科学上网。
+   ```shell
+   $ docker images
+   $ docker run --name dst-admin -d -p8080:8080 -p10888:10888/udp -p10998-10999:10998-10999/udp wolfgang/dst-admin:v1.5.0
+   ```

--- a/docker/dst_admin_docker.sh
+++ b/docker/dst_admin_docker.sh
@@ -1,19 +1,86 @@
 #!/bin/bash
 
-CONTAINER_ALREADY_STARTED="DST_ADMIN_ALREADY_STARTED_PLACEHOLDER"
-if [ ! -e $CONTAINER_ALREADY_STARTED ]; then
-    touch $CONTAINER_ALREADY_STARTED
-    echo "---------------------------------------------"
-    echo "-- 首次启动dst-admin 准备安装饥荒服务端 请等待 --"
-    echo "---------------------------------------------"
-    wget https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz -P ~/steamcmd
-    tar -zxvf ~/steamcmd/steamcmd_linux.tar.gz -C ~/steamcmd
-    bash ~/steamcmd/steamcmd.sh +login anonymous +force_install_dir ~/dst +app_update 343050 validate +quit
-    cp ~/steamcmd/linux32/libstdc++.so.6 ~/dst/bin/lib32/
-    mkdir -p ~/.klei/DoNotStarveTogether/MyDediServer
-fi
+USER_DIR=$(cd ~ && pwd -P)
 
-echo "-------------------"
-echo "-- 启动dst-admin --"
-echo "-------------------"
+function docker_log() {
+  echo "[dst_admin_docker.sh][$(date +'%Y-%m-%d %H:%M:%S')] $1"
+}
+
+docker_log "------------------------------------------------------------------"
+docker_log "-- 本次启动时间: $(date +'%Y-%m-%d %H:%M:%S')"
+docker_log "------------------------------------------------------------------"
+docker_log "-- 欢迎使用 dst-admin docker镜像"
+docker_log "-- 镜像帮助及常见问题: https://hub.docker.com/r/dzzhyk/dst-admin"
+docker_log "-- 镜像作者: dzzhyk@qq.com"
+docker_log "-- 更新时间: 2023-01-26 14:26:06"
+docker_log "------------------------------------------------------------------"
+docker_log "-- STEP 1 检查依赖命令安装情况"
+docker_log "------------------------------------------------------------------"
+docker_log "当前用户: [$(whoami)]:${USER_DIR}"
+cmds=(wget java screen sudo tar)
+for i in ${cmds[*]}; do
+  if command -v $i >/dev/null 2>&1; then
+    docker_log "already exists: ${i}"
+  else
+    docker_log "not exists: ${i}, try to install..."
+    apt-get install -y --no-install-recommends --no-install-suggests $i
+  fi
+done
+docker_log "------------------------------------------------------------------"
+docker_log "-- STEP 1 完成"
+docker_log "------------------------------------------------------------------"
+
+docker_log "------------------------------------------------------------------"
+docker_log "-- STEP 2 检查steamcmd安装情况并更新"
+docker_log "------------------------------------------------------------------"
+retry=1
+while [ ! -d "${USER_DIR}/steamcmd" ] || [ ! -e "${USER_DIR}/steamcmd/steamcmd.sh" ]; do
+  if [ $retry -gt 3 ]; then
+    docker_log "重试3次下载steamcmd失败，请检查网络连接，然后重启容器(docker restart)以触发下载"
+    exit -2
+  fi
+  docker_log "未找到可用steamcmd, 开始安装steamcmd, try: ${retry}"
+  wget http://media.steampowered.com/installer/steamcmd_linux.tar.gz -P $USER_DIR/steamcmd
+  tar -zxvf $USER_DIR/steamcmd/steamcmd_linux.tar.gz -C $USER_DIR/steamcmd
+  sleep 3
+  ((retry++))
+done
+docker_log "------------------------------------------------------------------"
+docker_log "-- 尝试更新steamcmd"
+docker_log "-- 更新速度依据宿主机网速决定"
+docker_log "------------------------------------------------------------------"
+bash $USER_DIR/steamcmd/steamcmd.sh +quit
+docker_log "------------------------------------------------------------------"
+docker_log "-- STEP 2 完成"
+docker_log "------------------------------------------------------------------"
+
+docker_log "------------------------------------------------------------------"
+docker_log "-- STEP 3 检查饥荒服务端安装情况并更新"
+docker_log "-- 安装速度依据宿主机网速决定，约需要5~10分钟"
+docker_log "------------------------------------------------------------------"
+retry=1
+while [ ! -d "${USER_DIR}/dst" ] || [ ! -e "${USER_DIR}/dst/bin/dontstarve_dedicated_server_nullrenderer" ]; do
+  if [ $retry -gt 3 ]; then
+    docker_log "重试3次下载饥荒服务端失败，请检查网络连接，然后重启容器(docker restart)以触发下载"
+    exit -2
+  fi
+  docker_log "未找到可用饥荒服务端, 开始安装饥荒服务端, try: ${retry}"
+  bash $USER_DIR/steamcmd/steamcmd.sh +force_install_dir $USER_DIR/dst +login anonymous +app_update 343050 validate +quit
+  cp $USER_DIR/steamcmd/linux32/libstdc++.so.6 $USER_DIR/dst/bin/lib32/
+  mkdir -p $USER_DIR/.klei/DoNotStarveTogether/MyDediServer
+  sleep 3
+  ((retry++))
+done
+docker_log "------------------------------------------------------------------"
+docker_log "-- 尝试更新饥荒服务端"
+docker_log "-- 更新速度依据宿主机网速决定"
+docker_log "------------------------------------------------------------------"
+bash $USER_DIR/steamcmd/steamcmd.sh +force_install_dir $USER_DIR/dst +login anonymous +app_update 343050 validate +quit
+docker_log "------------------------------------------------------------------"
+docker_log "-- STEP 3 完成"
+docker_log "------------------------------------------------------------------"
+
+docker_log "------------------------------------------------------------------"
+docker_log "-- STEP 4 启动dst-admin管理端"
+docker_log "------------------------------------------------------------------"
 java -jar -Xms256m -Xmx256m ./dst-admin.jar


### PR DESCRIPTION
新年好！鉴于最近docker镜像的一些问题，做了一些修改
1. 完善了Docker日志输出，现在容器各阶段日志比较清晰
2. 对于网络错误导致的下载失败问题，容器apt源改为清华源，添加重试与提示
3. 优化了Docker镜像大小，目前仅为190M（缩小了40M）
4. READMD内容docker相关更新，开服端口缺少udp映射修正 #56 #19 
5. 开服测试已通过

![B8DD6C5F2E406CDBC774FE768082FDCB](https://user-images.githubusercontent.com/36625372/215047113-da9607c8-7286-48a5-9bc2-dffeb3222a05.jpg)

目前已知问题：
1. 管理端缺少一个强制终止饥荒服务端的入口，有时服务器启动失败短时间内再次启动日志会报端口占用：SOCKET_PORT_ALREADY_IN_USE (5)