### PR TITLE
fix: 解决构建Docker镜像失败问题

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,13 +42,16 @@ RUN dpkg --add-architecture i386 \
         libxext6 \
         libxi6 \
         libxrender1 \
-        libxtst6
+        libxtst6 \
+        procps \
+        inetutils-ping
 
 
 # amd64 openjdk-8-jre-headless
 RUN wget http://snapshot.debian.org/archive/debian-security/20220210T090326Z/pool/updates/main/o/openjdk-8/openjdk-8-jre-headless_8u312-b07-1~deb9u1_amd64.deb
 RUN dpkg -i openjdk-8-jre-headless_8u312-b07-1~deb9u1_amd64.deb
 RUN apt-get clean
+RUN rm -rf openjdk-8-jre-headless_8u312-b07-1~deb9u1_amd64.deb
 
 EXPOSE 8080/tcp
 EXPOSE 10888/udp

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM debian:bullseye-slim
 
 ENV LANG C.UTF-8
 RUN rm -f /etc/localtime \
@@ -6,10 +6,10 @@ RUN rm -f /etc/localtime \
     && echo "Asia/Shanghai" > /etc/timezone
 
 RUN echo "" > /etc/apt/sources.list
-RUN echo "deb http://mirrors.tuna.tsinghua.edu.cn/debian/ stretch main contrib non-free" >> /etc/apt/sources.list
-RUN echo "deb http://mirrors.tuna.tsinghua.edu.cn/debian/ stretch-updates main contrib non-free" >> /etc/apt/sources.list
-RUN echo "deb http://mirrors.tuna.tsinghua.edu.cn/debian/ stretch-backports main contrib non-free" >> /etc/apt/sources.list
-RUN echo "deb http://mirrors.tuna.tsinghua.edu.cn/debian-security stretch/updates main contrib non-free" >> /etc/apt/sources.list
+RUN echo "deb http://mirrors.tuna.tsinghua.edu.cn/debian/ bullseye main contrib non-free" >> /etc/apt/sources.list
+RUN echo "deb http://mirrors.tuna.tsinghua.edu.cn/debian/ bullseye-updates main contrib non-free" >> /etc/apt/sources.list
+RUN echo "deb http://mirrors.tuna.tsinghua.edu.cn/debian/ bullseye-backports main contrib non-free" >> /etc/apt/sources.list
+RUN echo "deb http://mirrors.tuna.tsinghua.edu.cn/debian-security bullseye-security main contrib non-free" >> /etc/apt/sources.list
 
 VOLUME /root
 
@@ -22,15 +22,33 @@ RUN dpkg --add-architecture i386 \
     && apt-get install -y --no-install-recommends --no-install-suggests  \
         libstdc++6:i386 \
         libgcc1:i386 \
-        lib32gcc1 \
+        lib32gcc-s1 \
         lib32stdc++6 \
         libcurl4-gnutls-dev:i386 \
         wget \
         ca-certificates \
-        openjdk-8-jre \
         screen \
         sudo \
-    && apt-get clean
+        ca-certificates-java \
+        java-common \
+        libcups2 \
+        liblcms2-2 \
+        libjpeg62-turbo \
+        libfontconfig1 \
+        libnss3 \
+        libfreetype6 \
+        libpcsclite1 \
+        libx11-6 \
+        libxext6 \
+        libxi6 \
+        libxrender1 \
+        libxtst6
+
+
+# amd64 openjdk-8-jre-headless
+RUN wget http://snapshot.debian.org/archive/debian-security/20220210T090326Z/pool/updates/main/o/openjdk-8/openjdk-8-jre-headless_8u312-b07-1~deb9u1_amd64.deb
+RUN dpkg -i openjdk-8-jre-headless_8u312-b07-1~deb9u1_amd64.deb
+RUN apt-get clean
 
 EXPOSE 8080/tcp
 EXPOSE 10888/udp

--- a/docker/README-zh.md
+++ b/docker/README-zh.md
@@ -1,7 +1,7 @@
 # Docker 构建指南
 
 - author: [@dzzhyk](https://github.com/dzzhyk)
-- update: 2023-01-27 11:44:11
+- update: 2024-03-03 14:14:30
 
 **首先请确保服务器已经安装docker环境，且服务器架构amd64 (操作系统: Win|MacOS|Linux均可)**
 
@@ -30,7 +30,7 @@
     $ docker logs dst-admin
     ```
 
-5. 如果你使用了某些Docker镜像源，那么可能latest拉取到的非最新版本，推荐你用docker官方国内源 https://registry.docker-cn.com
+5. 如果你使用了某些Docker镜像源，那么可能latest拉取到的非最新版本，推荐你用docker官方源或者阿里云分流镜像
 
 6. 容器启动时会自动检查steamcmd和饥荒服务端更新，手动触发方式：
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,7 +1,7 @@
 # Docker Support
 
 - author: [@dzzhyk](https://github.com/dzzhyk)
-- update: 2023-01-27 11:44:11
+- update: 2024-03-03 14:14:30
 
 **Make sure install Docker env FIRST with arch type: amd64 (Win|MacOS|Linux)**
 

--- a/docker/dst_admin_docker.sh
+++ b/docker/dst_admin_docker.sh
@@ -3,51 +3,51 @@
 USER_DIR=$(cd ~ && pwd -P)
 
 function docker_log() {
-  echo "[dst_admin_docker.sh][$(date +'%Y-%m-%d %H:%M:%S')] $1"
+    echo "[dst_admin_docker.sh][$(date +'%Y-%m-%d %H:%M:%S')] $1"
 }
 
 docker_log "------------------------------------------------------------------"
 docker_log "-- 本次启动时间: $(date +'%Y-%m-%d %H:%M:%S')"
 docker_log "------------------------------------------------------------------"
-docker_log "-- 欢迎使用 dst-admin docker镜像"
-docker_log "-- 镜像帮助及常见问题: https://hub.docker.com/r/dzzhyk/dst-admin"
+docker_log "-- 欢迎使用 dst-admin docker镜像喵~"
+docker_log "-- 镜像用法、更新日志及常见问题: https://hub.docker.com/r/dzzhyk/dst-admin"
 docker_log "-- 镜像作者: dzzhyk@qq.com"
-docker_log "-- 更新时间: 2023-01-26 14:26:06"
+docker_log "-- 更新时间: 2024-03-03 14:14:30"
 docker_log "------------------------------------------------------------------"
-docker_log "-- STEP 1 检查依赖命令安装情况"
+docker_log "-- STEP 1 检查*必要*命令安装情况喵!"
 docker_log "------------------------------------------------------------------"
 docker_log "当前用户: [$(whoami)]:${USER_DIR}"
-cmds=(wget java screen sudo tar)
+cmds=(wget java screen sudo tar ps ping)
 for i in ${cmds[*]}; do
-  if command -v $i >/dev/null 2>&1; then
-    docker_log "already exists: ${i}"
-  else
-    docker_log "not exists: ${i}, try to install..."
-    apt-get install -y --no-install-recommends --no-install-suggests $i
-  fi
+    if command -v $i >/dev/null 2>&1; then
+        docker_log "required command exists: ${i}"
+    else
+        docker_log "required command NOT exists: ${i}, failed"
+        exit -2
+    fi
 done
 docker_log "------------------------------------------------------------------"
 docker_log "-- STEP 1 完成"
 docker_log "------------------------------------------------------------------"
 
 docker_log "------------------------------------------------------------------"
-docker_log "-- STEP 2 检查steamcmd安装情况并更新"
+docker_log "-- STEP 2 检查steamcmd安装情况并更新喵~"
 docker_log "------------------------------------------------------------------"
 retry=1
 while [ ! -d "${USER_DIR}/steamcmd" ] || [ ! -e "${USER_DIR}/steamcmd/steamcmd.sh" ]; do
-  if [ $retry -gt 3 ]; then
-    docker_log "重试3次下载steamcmd失败，请检查网络连接，然后重启容器(docker restart)以触发下载"
-    exit -2
-  fi
-  docker_log "未找到可用steamcmd, 开始安装steamcmd, try: ${retry}"
-  wget http://media.steampowered.com/installer/steamcmd_linux.tar.gz -P $USER_DIR/steamcmd
-  tar -zxvf $USER_DIR/steamcmd/steamcmd_linux.tar.gz -C $USER_DIR/steamcmd
-  sleep 3
-  ((retry++))
+    if [ $retry -gt 3 ]; then
+        docker_log "重试3次下载steamcmd失败，请检查网络连接，然后重启容器(docker restart)以触发下载喵~"
+        exit -2
+    fi
+    docker_log "喵~未找到可用的steamcmd, 第${retry}次尝试安装steamcmd喵~"
+    wget http://media.steampowered.com/installer/steamcmd_linux.tar.gz -P $USER_DIR/steamcmd
+    tar -zxvf $USER_DIR/steamcmd/steamcmd_linux.tar.gz -C $USER_DIR/steamcmd
+    sleep 3
+    ((retry++))
 done
 docker_log "------------------------------------------------------------------"
-docker_log "-- 尝试更新steamcmd"
-docker_log "-- 更新速度依据宿主机网速决定"
+docker_log "-- steamcmd找到喵!尝试更新steamcmd喵~"
+docker_log "-- 更新速度依据宿主机网速决定喵~"
 docker_log "------------------------------------------------------------------"
 bash $USER_DIR/steamcmd/steamcmd.sh +quit
 docker_log "------------------------------------------------------------------"
@@ -55,25 +55,25 @@ docker_log "-- STEP 2 完成"
 docker_log "------------------------------------------------------------------"
 
 docker_log "------------------------------------------------------------------"
-docker_log "-- STEP 3 检查饥荒服务端安装情况并更新"
+docker_log "-- STEP 3 检查饥荒服务端安装情况并更新喵~"
 docker_log "-- 安装速度依据宿主机网速决定，约需要5~10分钟"
 docker_log "------------------------------------------------------------------"
 retry=1
 while [ ! -d "${USER_DIR}/dst" ] || [ ! -e "${USER_DIR}/dst/bin/dontstarve_dedicated_server_nullrenderer" ]; do
-  if [ $retry -gt 3 ]; then
-    docker_log "重试3次下载饥荒服务端失败，请检查网络连接，然后重启容器(docker restart)以触发下载"
-    exit -2
-  fi
-  docker_log "未找到可用饥荒服务端, 开始安装饥荒服务端, try: ${retry}"
-  bash $USER_DIR/steamcmd/steamcmd.sh +force_install_dir $USER_DIR/dst +login anonymous +app_update 343050 validate +quit
-  cp $USER_DIR/steamcmd/linux32/libstdc++.so.6 $USER_DIR/dst/bin/lib32/
-  mkdir -p $USER_DIR/.klei/DoNotStarveTogether/MyDediServer
-  sleep 3
-  ((retry++))
+    if [ $retry -gt 3 ]; then
+        docker_log "重试3次下载饥荒服务端失败，请检查网络连接，然后重启容器(docker restart)以触发下载"
+        exit -2
+    fi
+    docker_log "未找到可用饥荒服务端, 第${retry}次尝试安装饥荒服务端喵~"
+    bash $USER_DIR/steamcmd/steamcmd.sh +force_install_dir $USER_DIR/dst +login anonymous +app_update 343050 validate +quit
+    ln -s /usr/lib32/libstdc++.so.6 $USER_DIR/dst/bin/lib32/libstdc++.so.6
+    mkdir -p $USER_DIR/.klei/DoNotStarveTogether/MyDediServer
+    sleep 3
+    ((retry++))
 done
 docker_log "------------------------------------------------------------------"
-docker_log "-- 尝试更新饥荒服务端"
-docker_log "-- 更新速度依据宿主机网速决定"
+docker_log "-- 尝试更新饥荒服务端喵~"
+docker_log "-- 更新速度依据宿主机网速决定喵~"
 docker_log "------------------------------------------------------------------"
 bash $USER_DIR/steamcmd/steamcmd.sh +force_install_dir $USER_DIR/dst +login anonymous +app_update 343050 validate +quit
 docker_log "------------------------------------------------------------------"
@@ -81,6 +81,8 @@ docker_log "-- STEP 3 完成"
 docker_log "------------------------------------------------------------------"
 
 docker_log "------------------------------------------------------------------"
-docker_log "-- STEP 4 启动dst-admin管理端"
+docker_log "-- STEP 4 启动dst-admin管理端喵~"
+docker_log "-- meow~meow~ 发现*任何*使用docker版本dst-admin问题，可以通过邮件反馈容器日志: dzzhyk@qq.com"
+docker_log "-- 导出日志: $ docker logs dst-admin(容器名) > dst-admin-docker.log"
 docker_log "------------------------------------------------------------------"
 java -jar -Xms256m -Xmx256m ./dst-admin.jar


### PR DESCRIPTION
- 由于stretch发行版已脱离LTS支持，导致自行构建镜像出现失败的问题，升级到bullseye版本
- 开服测试已通过